### PR TITLE
Add no_mention_emphasis option to disable emphasizing mentions

### DIFF
--- a/ext/greenmat/gm_markdown.c
+++ b/ext/greenmat/gm_markdown.c
@@ -68,6 +68,9 @@ static void rb_greenmat_md_flags(VALUE hash, unsigned int *enabled_extensions_p)
 	if (rb_hash_lookup(hash, CSTR2SYM("footnotes")) == Qtrue)
 		extensions |= MKDEXT_FOOTNOTES;
 
+	if (rb_hash_lookup(hash, CSTR2SYM("no_mention_emphasis")) == Qtrue)
+		extensions |= MKDEXT_NO_MENTION_EMPHASIS;
+
 	*enabled_extensions_p = extensions;
 }
 

--- a/ext/greenmat/markdown.c
+++ b/ext/greenmat/markdown.c
@@ -650,6 +650,11 @@ parse_emph1(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 					continue;
 			}
 
+			if (rndr->ext_flags & MKDEXT_NO_MENTION_EMPHASIS) {
+				if (is_part_of_mention(data + i, i))
+					continue;
+			}
+
 			work = rndr_newbuf(rndr, BUFFER_SPAN);
 			parse_inline(work, rndr, data, i);
 
@@ -680,6 +685,11 @@ parse_emph2(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 		i += len;
 
 		if (i + 1 < size && data[i] == c && data[i + 1] == c && i && !_isspace(data[i - 1])) {
+			if (rndr->ext_flags & MKDEXT_NO_MENTION_EMPHASIS) {
+				if (is_part_of_mention(data + i, i))
+					continue;
+			}
+
 			work = rndr_newbuf(rndr, BUFFER_SPAN);
 			parse_inline(work, rndr, data, i);
 
@@ -716,6 +726,11 @@ parse_emph3(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t size
 			continue;
 
 		if (i + 2 < size && data[i + 1] == c && data[i + 2] == c && rndr->cb.triple_emphasis) {
+			if (rndr->ext_flags & MKDEXT_NO_MENTION_EMPHASIS) {
+				if (is_part_of_mention(data + i, i))
+					continue;
+			}
+
 			/* triple symbol found */
 			struct buf *work = rndr_newbuf(rndr, BUFFER_SPAN);
 

--- a/ext/greenmat/markdown.h
+++ b/ext/greenmat/markdown.h
@@ -58,7 +58,8 @@ enum mkd_extensions {
 	MKDEXT_DISABLE_INDENTED_CODE = (1 << 9),
 	MKDEXT_HIGHLIGHT = (1 << 10),
 	MKDEXT_FOOTNOTES = (1 << 11),
-	MKDEXT_QUOTE = (1 << 12)
+	MKDEXT_QUOTE = (1 << 12),
+	MKDEXT_NO_MENTION_EMPHASIS = (1 << 13)
 };
 
 /* sd_callbacks - functions for rendering parsed data */

--- a/spec/greenmat/markdown_spec.rb
+++ b/spec/greenmat/markdown_spec.rb
@@ -21,7 +21,10 @@ module Greenmat
         ['A@_username_',        true],
         ['@*username*',         true],
         ['_foo_',               true],
-        ['_',                   false]
+        ['_',                   false],
+        ['_foo @username_',     false],
+        ['__foo @username__',   false],
+        ['___foo @username___', false]
       ].each do |text, emphasize|
         context "with text #{text.inspect}" do
           let(:text) { text }
@@ -44,6 +47,14 @@ module Greenmat
 
       context 'with text "@_username_"' do
         let(:text) { '@_username_' }
+
+        it 'emphasizes the text' do
+          expect(rendered_html).to include('<em>')
+        end
+      end
+
+      context 'with text "_foo @username_"' do
+        let(:text) { '_foo @username_' }
 
         it 'emphasizes the text' do
           expect(rendered_html).to include('<em>')

--- a/spec/greenmat/markdown_spec.rb
+++ b/spec/greenmat/markdown_spec.rb
@@ -1,0 +1,54 @@
+require 'greenmat'
+
+module Greenmat
+  RSpec.describe Markdown do
+    subject(:markdown) { Markdown.new(renderer, options) }
+    let(:renderer) { Render::HTML.new }
+    let(:options) { {} }
+    let(:rendered_html) { markdown.render(text) }
+
+    context 'with no_mention_emphasis option' do
+      let(:options) { { no_mention_emphasis: true } }
+
+      [
+        ['@_username_',         false],
+        ['@__username__',       false],
+        ['@___username___',     false],
+        ['@user__name__',       false],
+        ['@some__user__name__', false],
+        [' @_username_',        false],
+        ['あ@_username_',       false],
+        ['A@_username_',        true],
+        ['@*username*',         true],
+        ['_foo_',               true],
+        ['_',                   false]
+      ].each do |text, emphasize|
+        context "with text #{text.inspect}" do
+          let(:text) { text }
+
+          if emphasize
+            it 'emphasizes the text' do
+              expect(rendered_html).to include('<em>').or include('<strong>')
+            end
+          else
+            it 'does not emphasize the text' do
+              expect(rendered_html.chomp).to eq("<p>#{text.strip}</p>")
+            end
+          end
+        end
+      end
+    end
+
+    context 'without no_mention_emphasis option' do
+      let(:options) { {} }
+
+      context 'with text "@_username_"' do
+        let(:text) { '@_username_' }
+
+        it 'emphasizes the text' do
+          expect(rendered_html).to include('<em>')
+        end
+      end
+    end
+  end
+end

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -4,11 +4,16 @@ require 'test_helper'
 class MarkdownTest < Greenmat::TestCase
 
   def setup
-    @markdown = Greenmat::Markdown.new(Greenmat::Render::HTML)
+    @markdown = Greenmat::Markdown.new(Greenmat::Render::HTML, greenmat_options)
   end
 
   def render_with(flags, text)
+    flags = greenmat_options.merge(flags)
     Greenmat::Markdown.new(Greenmat::Render::HTML, flags).render(text)
+  end
+
+  def greenmat_options
+    { no_mention_emphasis: true }
   end
 
   def test_that_simple_one_liner_goes_to_html


### PR DESCRIPTION
With the `no_mention_emphasis` option, you can prevent mentions with username including underscores like `@_username_` from being emphasized as `@<em>username</em>`.
