### PR TITLE
Avoid using `class` attribute for code block metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ before_install:
 install: travis_retry bundle install --without=benchmark
 
 rvm:
-  - 2.0.0
-  - 2.1.10
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.2
+  - 2.3
+  - 2.4
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Change `<code>` attribute for code block metadata (language) from `class` to `data-metadata`.
+  Note that this is a breaking change, though you won't face this breakage if you're using greenmat through qiita-markdown gem and updating both gems.
+
 ## v3.2.2.2
 
 * Fix bugs in UTF-8 handling. [#3](https://github.com/increments/greenmat/pull/3) ([@gfx](https://github.com/gfx))

--- a/ext/greenmat/html.c
+++ b/ext/greenmat/html.c
@@ -125,10 +125,10 @@ rndr_blockcode(struct buf *ob, const struct buf *text, const struct buf *lang, v
 	if (lang && lang->size) {
 		size_t i, cls;
 		if (options->flags & HTML_PRETTIFY) {
-			BUFPUTSL(ob, "<pre><code class=\"prettyprint ");
+			BUFPUTSL(ob, "<pre><code class=\"prettyprint\" data-metadata=\"");
 			cls++;
 		} else {
-			BUFPUTSL(ob, "<pre><code class=\"");
+			BUFPUTSL(ob, "<pre><code data-metadata=\"");
 		}
 
 		for (i = 0, cls = 0; i < lang->size; ++i, ++cls) {

--- a/greenmat.gemspec
+++ b/greenmat.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.executables = ["greenmat"]
   s.require_paths = ["lib"]
 
+  s.add_development_dependency "activesupport"
   s.add_development_dependency "nokogiri", "~> 1.6.0"
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "rake-compiler", "~> 0.8.3"

--- a/spec/greenmat/markdown_spec.rb
+++ b/spec/greenmat/markdown_spec.rb
@@ -1,4 +1,5 @@
 require 'greenmat'
+require "active_support/core_ext/string/strip"
 
 module Greenmat
   RSpec.describe Markdown do
@@ -58,6 +59,27 @@ module Greenmat
 
         it 'emphasizes the text' do
           expect(rendered_html).to include('<em>')
+        end
+      end
+    end
+
+    context 'with fenced_code_blocks option' do
+      let(:options) { { fenced_code_blocks: true } }
+
+      context 'with language and filename syntax' do
+        let(:text) do
+          <<-EOS.strip_heredoc
+            ```ruby:example.rb
+            puts :foo
+            ```
+          EOS
+        end
+
+        it 'generates <code> tag with data-metadata attribute' do
+          expect(rendered_html).to eq <<-EOS.strip_heredoc
+            <pre><code data-metadata="ruby:example.rb">puts :foo
+            </code></pre>
+          EOS
         end
       end
     end

--- a/test/greenmat_compat_test.rb
+++ b/test/greenmat_compat_test.rb
@@ -15,13 +15,13 @@ class GreenmatCompatTest < Greenmat::TestCase
   def test_compat_api_knows_fenced_code_extension
     text = "```ruby\nx = 'foo'\n```"
     html = GreenmatCompat.new(text, :fenced_code).to_html
-    html_equal "<pre><code class=\"ruby\">x = 'foo'\n</code></pre>\n", html
+    html_equal "<pre><code data-metadata=\"ruby\">x = 'foo'\n</code></pre>\n", html
   end
 
   def test_compat_api_ignores_gh_blockcode_extension
     text = "```ruby\nx = 'foo'\n```"
     html = GreenmatCompat.new(text, :fenced_code, :gh_blockcode).to_html
-    html_equal "<pre><code class=\"ruby\">x = 'foo'\n</code></pre>\n", html
+    html_equal "<pre><code data-metadata=\"ruby\">x = 'foo'\n</code></pre>\n", html
   end
 
   def test_compat_api_knows_no_intraemphasis_extension

--- a/test/html_render_test.rb
+++ b/test/html_render_test.rb
@@ -218,7 +218,7 @@ Markdown
     renderer = Greenmat::Markdown.new(@rndr[:prettify], fenced_code_blocks: true)
     output = renderer.render(text)
 
-    assert output.include?("<code class=\"prettyprint ruby\">")
+    assert output.include?("<code class=\"prettyprint\" data-metadata=\"ruby\">")
   end
 
   def test_safe_links_only_with_anchors

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -264,7 +264,7 @@ fenced
   def test_that_fenced_flag_works_with_utf8
     text = "```ム\ncode\n```"
     out = Greenmat::Markdown.new(Greenmat::Render::HTML, :fenced_code_blocks => true).render(text)
-    assert out.include?(%{<pre><code class="ム">})
+    assert out.include?(%{<pre><code data-metadata="ム">})
   end
 
   def test_that_indented_flag_works


### PR DESCRIPTION
... so that we can sanitize `class` attribute inputted by user in post-process.

Ref: https://github.com/increments/qiita-markdown/pull/46