### PR TITLE
Relax max nesting

### DIFF
--- a/ext/greenmat/gm_markdown.c
+++ b/ext/greenmat/gm_markdown.c
@@ -20,6 +20,8 @@ VALUE rb_cMarkdown;
 
 extern VALUE rb_cRenderBase;
 
+static size_t MAX_NESTING = 32;
+
 static void rb_greenmat_md_flags(VALUE hash, unsigned int *enabled_extensions_p)
 {
 	unsigned int extensions = 0;
@@ -99,7 +101,7 @@ static VALUE rb_greenmat_md__new(int argc, VALUE *argv, VALUE klass)
 
 	Data_Get_Struct(rb_rndr, struct rb_greenmat_rndr, rndr);
 
-	markdown = sd_markdown_new(extensions, 16, &rndr->callbacks, &rndr->options);
+	markdown = sd_markdown_new(extensions, MAX_NESTING, &rndr->callbacks, &rndr->options);
 	if (!markdown)
 		rb_raise(rb_eRuntimeError, "Failed to create new Renderer class");
 

--- a/spec/greenmat/markdown_spec.rb
+++ b/spec/greenmat/markdown_spec.rb
@@ -83,5 +83,86 @@ module Greenmat
         end
       end
     end
+
+    context 'with deeply nested list' do
+      let(:text) do
+        <<-EOS.strip_heredoc
+          * 1
+              * 2
+                  * 3
+                      * 4
+                          * 5
+                              * 6
+                                  * 7
+                                      * 8
+                                          * 9
+                                              * 10
+                                                  * 11
+        EOS
+      end
+
+      it 'renders the list up to 5 nesting and then gives up' do
+        expect(rendered_html).to eq <<-EOS.strip_heredoc
+          <ul>
+          <li>1
+
+          <ul>
+          <li>2
+
+          <ul>
+          <li>3
+
+          <ul>
+          <li>4
+
+          <ul>
+          <li>5
+
+          <ul>
+          <li></li>
+          </ul></li>
+          </ul></li>
+          </ul></li>
+          </ul></li>
+          </ul></li>
+          </ul>
+        EOS
+      end
+    end
+
+    context 'with a deeply nested structure that can exist in the wild' do
+      let(:text) do
+        <<-EOS.strip_heredoc
+          > > * 1
+          > >     * 2
+          > >         * 3
+          > >             * [_**Qiita**_](https://qiita.com)
+        EOS
+      end
+
+      it 'gives up rendering it properly' do
+        expect(rendered_html).to eq <<-EOS.strip_heredoc
+          <blockquote>
+          <blockquote>
+          <ul>
+          <li>1
+
+          <ul>
+          <li>2
+
+          <ul>
+          <li>3
+
+          <ul>
+          <li><a href="https://qiita.com">_**Qiita**_</a></li>
+          </ul></li>
+          </ul></li>
+          </ul></li>
+          </ul>
+          </blockquote>
+          </blockquote>
+        EOS
+      end
+    end
   end
 end

--- a/spec/greenmat/markdown_spec.rb
+++ b/spec/greenmat/markdown_spec.rb
@@ -101,7 +101,7 @@ module Greenmat
         EOS
       end
 
-      it 'renders the list up to 5 nesting and then gives up' do
+      it 'renders the list up to 10 nesting and then gives up' do
         expect(rendered_html).to eq <<-EOS.strip_heredoc
           <ul>
           <li>1
@@ -119,7 +119,27 @@ module Greenmat
           <li>5
 
           <ul>
+          <li>6
+
+          <ul>
+          <li>7
+
+          <ul>
+          <li>8
+
+          <ul>
+          <li>9
+
+          <ul>
+          <li>10
+
+          <ul>
           <li></li>
+          </ul></li>
+          </ul></li>
+          </ul></li>
+          </ul></li>
+          </ul></li>
           </ul></li>
           </ul></li>
           </ul></li>
@@ -140,7 +160,7 @@ module Greenmat
         EOS
       end
 
-      it 'gives up rendering it properly' do
+      it 'renders it properly' do
         expect(rendered_html).to eq <<-EOS.strip_heredoc
           <blockquote>
           <blockquote>
@@ -154,7 +174,7 @@ module Greenmat
           <li>3
 
           <ul>
-          <li><a href="https://qiita.com">_**Qiita**_</a></li>
+          <li><a href="https://qiita.com"><em><strong>Qiita</strong></em></a></li>
           </ul></li>
           </ul></li>
           </ul></li>


### PR DESCRIPTION
The default max nesting 16 is a bit too strict as sometimes it cannot render real-world complex documents.

Ref: 

* https://github.com/increments/Qiita/issues/10990#issuecomment-396116172
* https://github.com/vmg/redcarpet/issues/115