### PR TITLE
Bump version to 3.5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v3.5.1.0
+
+* Update base Redcarpet version to 3.5.1.
+
 ## v3.2.2.4
 
 * Relax max nesting.


### PR DESCRIPTION
# What

- Update base Redcarpet version to 3.5.1.

