### PR TITLE
Add custom block notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Support custom block notation.
+  * It starts with `:::` and ends with `:::`.
+  * Output a `<div data-type="customblock" data-metadata="">` element.
+  * Passes the string following `:::` to the `data-metadata` attribute.
+
 ## v3.5.1.1
 
 * Unsupport details and summary tags.

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require 'rake/extensiontask'
 require 'digest/md5'
 
 task :default => [:test, :spec]
+task :spec => [:compile]
 
 # Gem Spec
 gem_spec = Gem::Specification.load('greenmat.gemspec')

--- a/ext/greenmat/gm_markdown.c
+++ b/ext/greenmat/gm_markdown.c
@@ -48,6 +48,9 @@ static void rb_greenmat_md_flags(VALUE hash, unsigned int *enabled_extensions_p)
 	if (rb_hash_lookup(hash, CSTR2SYM("fenced_code_blocks")) == Qtrue)
 		extensions |= MKDEXT_FENCED_CODE;
 
+	if (rb_hash_lookup(hash, CSTR2SYM("fenced_custom_blocks")) == Qtrue)
+		extensions |= MKDEXT_FENCED_CUSTOM;
+
 	if (rb_hash_lookup(hash, CSTR2SYM("disable_indented_code_blocks")) == Qtrue)
 		extensions |= MKDEXT_DISABLE_INDENTED_CODE;
 

--- a/ext/greenmat/gm_render.c
+++ b/ext/greenmat/gm_render.c
@@ -55,6 +55,12 @@ rndr_blockcode(struct buf *ob, const struct buf *text, const struct buf *lang, v
 }
 
 static void
+rndr_blockcustom(struct buf *ob, const struct buf *text, const struct buf *type, void *opaque)
+{
+	BLOCK_CALLBACK("block_custom", 2, buf2str(text), buf2str(type));
+}
+
+static void
 rndr_blockquote(struct buf *ob, const struct buf *text, void *opaque)
 {
 	BLOCK_CALLBACK("block_quote", 1, buf2str(text));
@@ -293,6 +299,7 @@ rndr_link_attributes(struct buf *ob, const struct buf *url, void *opaque)
 
 static struct sd_callbacks rb_greenmat_callbacks = {
 	rndr_blockcode,
+	rndr_blockcustom,
 	rndr_blockquote,
 	rndr_raw_block,
 	rndr_header,
@@ -331,6 +338,7 @@ static struct sd_callbacks rb_greenmat_callbacks = {
 
 static const char *rb_greenmat_method_names[] = {
 	"block_code",
+	"block_custom",
 	"block_quote",
 	"block_html",
 	"header",

--- a/ext/greenmat/markdown.h
+++ b/ext/greenmat/markdown.h
@@ -64,13 +64,15 @@ enum mkd_extensions {
 	MKDEXT_HIGHLIGHT = (1 << 10),
 	MKDEXT_FOOTNOTES = (1 << 11),
 	MKDEXT_QUOTE = (1 << 12),
-	MKDEXT_NO_MENTION_EMPHASIS = (1 << 13)
+	MKDEXT_NO_MENTION_EMPHASIS = (1 << 13),
+	MKDEXT_FENCED_CUSTOM = (1 << 14)
 };
 
 /* sd_callbacks - functions for rendering parsed data */
 struct sd_callbacks {
 	/* block level callbacks - NULL skips the block */
 	void (*blockcode)(struct buf *ob, const struct buf *text, const struct buf *lang, void *opaque);
+	void (*blockcustom)(struct buf *ob, const struct buf *text, const struct buf *type, void *opaque);
 	void (*blockquote)(struct buf *ob, const struct buf *text, void *opaque);
 	void (*blockhtml)(struct buf *ob,const  struct buf *text, void *opaque);
 	void (*header)(struct buf *ob, const struct buf *text, int level, void *opaque);

--- a/spec/greenmat/markdown_spec.rb
+++ b/spec/greenmat/markdown_spec.rb
@@ -184,5 +184,48 @@ module Greenmat
         EOS
       end
     end
+
+    context 'with fenced_custom_blocks option' do
+      let(:options) { { fenced_custom_blocks: true } }
+
+      context 'with custom block with any metadata' do
+        let(:text) do
+          <<-EOS.strip_heredoc
+            :::foo bar
+            message
+            :::
+          EOS
+        end
+
+        it 'renders text with <div> tag that have customblock class & metadata in a data-metadata attribute' do
+          expect(rendered_html).to eq <<-EOS.strip_heredoc
+            <div data-type="customblock" data-metadata="foo bar">message
+            </div>
+          EOS
+        end
+      end
+    end
+
+    context 'without fenced_custom_blocks option' do
+      let(:options) { {} }
+
+      context 'with custom block with any metadata' do
+        let(:text) do
+          <<-EOS.strip_heredoc
+            :::foo bar
+            message
+            :::
+          EOS
+        end
+
+        it 'renders text with p tag' do
+          expect(rendered_html).to eq <<-EOS.strip_heredoc
+            <p>:::foo bar
+            message
+            :::</p>
+          EOS
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
- Add custom block notation.
  - It starts with `:::` and ends with `:::`.
  - Output a `<div data-type="customblock">` element.
  - Passes the string following `:::` to the `data-metadata` attribute
  - See specs for detailed I/O examples.
    - https://github.com/increments/greenmat/blob/186b7116b569d79a3f1d4282a2d577d912537126/spec/greenmat/markdown_spec.rb#L191-L207