### PR TITLE
Support cpu archtecture for arm64/aarch64 systems (like Apple's M1) / Remove support for ruby 2.5 and below

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-18.04', 'macos-latest']
-        ruby: ['2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.7']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
         experimental: [false]
         include:
           - os: 'ubuntu-18.04'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Bump nokogiri from 1.6.0 to 1.11.7
+  * Support cpu archtecture for arm64/aarch64 systems (like Apple's M1)
 * Change ci platform to Github Actions
 
 ## v3.5.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Remove support for ruby 2.5 and below
 * Bump nokogiri from 1.6.0 to 1.11.7
   * Support cpu archtecture for arm64/aarch64 systems (like Apple's M1)
 * Change ci platform to Github Actions

--- a/greenmat.gemspec
+++ b/greenmat.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/increments/greenmat'
   s.authors = ["Natacha Porté", "Vicent Martí"]
   s.license = 'MIT'
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.files = `git ls-files -z`.split("\x0")
   s.test_files = s.files.grep(%r{^(test|spec|features)/})

--- a/greenmat.gemspec
+++ b/greenmat.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "activesupport"
-  s.add_development_dependency "nokogiri", "~> 1.6.0"
+  s.add_development_dependency "nokogiri", "~> 1.11.7"
   s.add_development_dependency "rake", "~> 12.2.1"
   s.add_development_dependency "rake-compiler", "~> 1.0.3"
   s.add_development_dependency "rspec", "~> 3.2"


### PR DESCRIPTION
## What

- Support cpu archtecture for arm64/aarch64 (like Apple's M1)
    - Bump nokogiri from 1.6.0 to 1.11.7
- Remove support for ruby 2.5 and below
