### PR TITLE
Bump version to 3.5.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v3.5.1.3
+
 * Remove support for ruby 2.5 and below
 * Bump nokogiri from 1.6.0 to 1.11.7
   * Support cpu archtecture for arm64/aarch64 systems (like Apple's M1)

--- a/lib/greenmat/version.rb
+++ b/lib/greenmat/version.rb
@@ -1,3 +1,3 @@
 module Greenmat
-  VERSION = '3.5.1.2'
+  VERSION = '3.5.1.3'
 end


### PR DESCRIPTION
## v3.5.1.3

- [#15](https://github.com/increments/greenmat/pull/15): Support cpu archtecture for arm64/aarch64 systems (like Apple's M1) / Remove support for ruby 2.5 and below by @mziyut