### PR TITLE
Support ruby version for 3.0, 3.1 and dropped Ruby 2.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-18.04', 'macos-latest']
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.6', '2.7', '3.0', '3.1']
         experimental: [false]
         include:
           - os: 'ubuntu-18.04'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Dropped Ruby 2.5 support
 * Support ruby version for 3.0, 3.1
 
 ## v3.5.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Support ruby version for 3.0, 3.1
+
 ## v3.5.1.3
 
 * Remove support for ruby 2.5 and below

--- a/greenmat.gemspec
+++ b/greenmat.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "activesupport"
-  s.add_development_dependency "nokogiri", "~> 1.11.7"
-  s.add_development_dependency "rake", "~> 12.2.1"
+  s.add_development_dependency "nokogiri", "~> 1.13.0"
+  s.add_development_dependency "rake", "~> 13"
   s.add_development_dependency "rake-compiler", "~> 1.0.3"
   s.add_development_dependency "rspec", "~> 3.2"
-  s.add_development_dependency "test-unit", "~> 3.2.3"
+  s.add_development_dependency "test-unit", "~> 3.5.3"
 end

--- a/greenmat.gemspec
+++ b/greenmat.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/increments/greenmat'
   s.authors = ["Natacha Porté", "Vicent Martí"]
   s.license = 'MIT'
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
 
   s.files = `git ls-files -z`.split("\x0")
   s.test_files = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
## What
Closes https://github.com/increments/greenmat/issues/17

- Support ruby version for 3.0, 3.1 .
    - This pull request includes upgrades to dependent libraries (rake, nokogiri, test-unit) .
- Dropped Ruby 2.5 support