### PR TITLE
Bump version to 3.5.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v3.5.1.4
+
 * Dropped Ruby 2.5 support
 * Support ruby version for 3.0, 3.1
 

--- a/lib/greenmat/version.rb
+++ b/lib/greenmat/version.rb
@@ -1,3 +1,3 @@
 module Greenmat
-  VERSION = '3.5.1.3'
+  VERSION = '3.5.1.4'
 end


### PR DESCRIPTION
## Release v3.5.1.4

- [#18](https://github.com/increments/greenmat/pull/18): Support ruby version for 3.0, 3.1 and dropped Ruby 2.5 support by @mziyut