### PR TITLE
Add deprecated text to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 # Greenmat
 
+> [!WARNING]
+> This repository is deprecated and no longer maintained.
+> Please use the new repository at [qiita-marker](https://github.com/increments/qiita_marker) instead.
+
 **Greenmat** is a Ruby library for Markdown processing, based on [Redcarpet](https://github.com/vmg/redcarpet).
 
 It's a core module of [qiita-markdown](https://github.com/increments/qiita-markdown) gem and not intended for direct use. If you are looking for Qiita-specified markdown processor, use qiita-markdown gem.


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->
## What

- Added a note to the README indicating that this repository is deprecated.
- The reason for deprecation is that we recommend using [qiita-marker](https://github.com/increments/qiita_marker) instead.

<img width="881" height="276" alt="screenshot" src="https://github.com/user-attachments/assets/82a72148-979f-4f62-a60d-e75a684f7ef0" />